### PR TITLE
Episode 6 - Update API version for ingress

### DIFF
--- a/episode-06/k8s-manifests/drupal-ingress-tls.yml
+++ b/episode-06/k8s-manifests/drupal-ingress-tls.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: drupal
@@ -17,5 +17,9 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: drupal
-          servicePort: 80
+          service:
+            name: drupal
+            port:
+              number: 80
+        path: /
+        pathType: ImplementationSpecific

--- a/episode-06/k8s-manifests/drupal-ingress.yml
+++ b/episode-06/k8s-manifests/drupal-ingress.yml
@@ -17,5 +17,5 @@ spec:
             port:
               number: 80
         path: /
-        pathType: Exact # | "Prefix" | "ImplementationSpecific "
+        pathType: ImplementationSpecific
 

--- a/episode-06/k8s-manifests/drupal-ingress.yml
+++ b/episode-06/k8s-manifests/drupal-ingress.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: drupal
@@ -12,5 +12,10 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: drupal
-          servicePort: 80
+          service:
+            name: drupal
+            port:
+              number: 80
+        path: /
+        pathType: Exact # | "Prefix" | "ImplementationSpecific "
+


### PR DESCRIPTION
Updating apiVersion for networking in episode-06 in drupal-ingress resource to v1 from v1beta1.

Followed answers in these resources to achieve equivalent behaviour:
- https://stackoverflow.com/a/64126069/5093093
- https://forum.linuxfoundation.org/discussion/858146/lab10-1-error-creating-ingress-rule-pathtype-must-be-specified
- https://docs.openshift.com/container-platform/4.6/rest_api/network_apis/ingress-networking-k8s-io-v1.html

I tested this change with my local cluster (albeit not running drupal). I selected `pathType: ImplementationSpecific` because that seems to forward the URI to the app where router can decide what to do.

---
Closes https://github.com/geerlingguy/kubernetes-101/issues/24
