### PR TITLE
Update embedded YouTube link to mirror

### DIFF
--- a/episode-01/index.html
+++ b/episode-01/index.html
@@ -47,7 +47,7 @@
       <div class="content">
         <h3>Back before music videos took over...</h3>
         <hr />
-        <style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube.com/embed/_OBlgSz8sSM?autoplay=1' frameborder='0' allowfullscreen></iframe></div>
+        <style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube.com/embed/0EqSXDwTq6U?autoplay=1' frameborder='0' allow="autoplay" allowfullscreen></iframe></div>
       </div>
     </div>
 </body>


### PR DESCRIPTION
Note that autoplay doesn't work for this video in chrome or safari. It works when adding `&mute=1` to the link.

Based on this [StackOverflow](https://stackoverflow.com/questions/40685142/youtube-autoplay-not-working) article it should also work with `allow="autoplay"` set in the iframe but I tested that and it doesn't work. I'm not sure how important the autoplay is so I just left it as is and updated the link. 

Cheers.