### PR TITLE
Issue #24: Replace `networking.k8s.io/v1` with `networking.k8s.io/v1beta1`.

### DIFF
--- a/episode-06/k8s-manifests/drupal-ingress-tls.yml
+++ b/episode-06/k8s-manifests/drupal-ingress-tls.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: drupal

--- a/episode-06/k8s-manifests/drupal-ingress.yml
+++ b/episode-06/k8s-manifests/drupal-ingress.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: drupal


### PR DESCRIPTION
Update ingress files to use `networking.k8s.io/v1` api version instead of the depricated `networking.k8s.io/v1beta1` api version.

Fixes #24.