### PR TITLE
Use new syntax for metrics-server

### DIFF
--- a/episode-05/values/metrics-server.yml
+++ b/episode-05/values/metrics-server.yml
@@ -2,5 +2,5 @@
 apiService:
   create: true
 extraArgs:
-  kubelet-preferred-address-types: InternalIP
-  kubelet-insecure-tls:
+  - --kubelet-preferred-address-types=InternalIP
+  - --kubelet-insecure-tls=true


### PR DESCRIPTION
extraArgs is now an array with 6.0.0 release of chart: https://github.com/bitnami/charts/tree/master/bitnami/metrics-server#to-600

See https://github.com/bitnami/charts/issues/10570